### PR TITLE
Use ActionArgs in v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'wannabe_bool'
 
 gem 'active_model_serializers', github: 'rails-api/active_model_serializers', ref: '95f832fd0e57ad5c960076c851bf553b88fb4430'
+gem 'action_args', github: 'Altech/action_args', ref: '98ce1b12168f0ef16ae344beb2efdb68a62649e3' # turn off global configuration.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/Altech/action_args.git
+  revision: 98ce1b12168f0ef16ae344beb2efdb68a62649e3
+  ref: 98ce1b12168f0ef16ae344beb2efdb68a62649e3
+  specs:
+    action_args (2.2.0)
+
+GIT
   remote: https://github.com/rails-api/active_model_serializers.git
   revision: 95f832fd0e57ad5c960076c851bf553b88fb4430
   ref: 95f832fd0e57ad5c960076c851bf553b88fb4430
@@ -144,6 +151,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  action_args!
   active_model_serializers!
   byebug
   listen (~> 3.0.5)

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -1,5 +1,6 @@
 class Api::V2::BaseController < ApplicationController
   include ActionController::Serialization
+  include ActionArgs::AbstractControllerMethods
 
   include Api::RestfulControllerConcern
 


### PR DESCRIPTION
## WHY

To list adhoc parameters (typically in `index` action).

## WHAT

* Use action_args in v2